### PR TITLE
Fixes #17060 - Decryption fails when using AES192

### DIFF
--- a/openpgp/packet/symmetric_key_encrypted.go
+++ b/openpgp/packet/symmetric_key_encrypted.go
@@ -88,8 +88,9 @@ func (ske *SymmetricKeyEncrypted) Decrypt(passphrase []byte) ([]byte, CipherFunc
 		return nil, ske.CipherFunc, errors.UnsupportedError("unknown cipher: " + strconv.Itoa(int(cipherFunc)))
 	}
 	plaintextKey = plaintextKey[1:]
-	if l := len(plaintextKey); l == 0 || l%cipherFunc.blockSize() != 0 {
-		return nil, cipherFunc, errors.StructuralError("length of decrypted key not a multiple of block size")
+	if l, k := len(plaintextKey), cipherFunc.KeySize(); l != k {
+		return nil, cipherFunc, errors.StructuralError("incorrect key size: Expected " +
+			strconv.Itoa(l) + " bytes, received " + strconv.Itoa(k))
 	}
 
 	return plaintextKey, cipherFunc, nil

--- a/openpgp/packet/symmetric_key_encrypted_test.go
+++ b/openpgp/packet/symmetric_key_encrypted_test.go
@@ -61,43 +61,53 @@ func TestSymmetricKeyEncrypted(t *testing.T) {
 const symmetricallyEncryptedHex = "8c0d04030302371a0b38d884f02060c91cf97c9973b8e58e028e9501708ccfe618fb92afef7fa2d80ddadd93cf"
 const symmetricallyEncryptedContentsHex = "cb1062004d14c4df636f6e74656e74732e0a"
 
-func TestSerializeSymmetricKeyEncrypted(t *testing.T) {
-	buf := bytes.NewBuffer(nil)
-	passphrase := []byte("testing")
-	const cipherFunc = CipherAES128
-	config := &Config{
-		DefaultCipher: cipherFunc,
+func TestSerializeSymmetricKeyEncryptedCiphers(t *testing.T) {
+	var ciphers = []CipherFunction{
+		Cipher3DES,
+		CipherCAST5,
+		CipherAES128,
+		CipherAES192,
+		CipherAES256,
 	}
+	for _, cipher := range ciphers {
+		buf := bytes.NewBuffer(nil)
+		passphrase := []byte("testing")
+		var cipherFunc = cipher
+		config := &Config{
+			DefaultCipher: cipherFunc,
+		}
 
-	key, err := SerializeSymmetricKeyEncrypted(buf, passphrase, config)
-	if err != nil {
-		t.Errorf("failed to serialize: %s", err)
-		return
-	}
+		key, err := SerializeSymmetricKeyEncrypted(buf, passphrase, config)
+		if err != nil {
+			t.Errorf("failed to serialize: %s", err)
+			return
+		}
 
-	p, err := Read(buf)
-	if err != nil {
-		t.Errorf("failed to reparse: %s", err)
-		return
-	}
-	ske, ok := p.(*SymmetricKeyEncrypted)
-	if !ok {
-		t.Errorf("parsed a different packet type: %#v", p)
-		return
-	}
+		p, err := Read(buf)
+		if err != nil {
+			t.Errorf("failed to reparse: %s", err)
+			return
+		}
 
-	if ske.CipherFunc != config.DefaultCipher {
-		t.Errorf("SKE cipher function is %d (expected %d)", ske.CipherFunc, config.DefaultCipher)
-	}
-	parsedKey, parsedCipherFunc, err := ske.Decrypt(passphrase)
-	if err != nil {
-		t.Errorf("failed to decrypt reparsed SKE: %s", err)
-		return
-	}
-	if !bytes.Equal(key, parsedKey) {
-		t.Errorf("keys don't match after Decrypt: %x (original) vs %x (parsed)", key, parsedKey)
-	}
-	if parsedCipherFunc != cipherFunc {
-		t.Errorf("cipher function doesn't match after Decrypt: %d (original) vs %d (parsed)", cipherFunc, parsedCipherFunc)
+		ske, ok := p.(*SymmetricKeyEncrypted)
+		if !ok {
+			t.Errorf("parsed a different packet type: %#v", p)
+			return
+		}
+
+		if ske.CipherFunc != config.DefaultCipher {
+			t.Errorf("SKE cipher function is %d (expected %d)", ske.CipherFunc, config.DefaultCipher)
+		}
+		parsedKey, parsedCipherFunc, err := ske.Decrypt(passphrase)
+		if err != nil {
+			t.Errorf("failed to decrypt reparsed SKE: %s", err)
+			return
+		}
+		if !bytes.Equal(key, parsedKey) {
+			t.Errorf("keys don't match after Decrypt: %x (original) vs %x (parsed)", key, parsedKey)
+		}
+		if parsedCipherFunc != cipherFunc {
+			t.Errorf("cipher function doesn't match after Decrypt: %d (original) vs %d (parsed)", cipherFunc, parsedCipherFunc)
+		}
 	}
 }


### PR DESCRIPTION
- Check to ensure key is AT LEAST the keysize specified by the cipher
- Test all the ciphers available in SymmetricKeyEncrypted